### PR TITLE
There was a problem with the fixtures (which caused the homepage to thro...

### DIFF
--- a/src/Sonata/Bundle/DemoBundle/DataFixtures/ORM/LoadPageData.php
+++ b/src/Sonata/Bundle/DemoBundle/DataFixtures/ORM/LoadPageData.php
@@ -195,7 +195,7 @@ CONTENT
         $gallery->setPage($homepage);
 
         $content->addChildren($text = $blockManager->create());
-        $text->setType('sonata.page.block.text');
+        $text->setType('sonata.block.service.text');
 
         $text->setPosition(3);
         $text->setEnabled(true);


### PR DESCRIPTION
...w an exception), one referencing an "sonata.page.block.text" which shouldv been "sonata.block.service.text" - corrected.
