### PR TITLE
Fixes the bootstrap to make it work on any travis accounts

### DIFF
--- a/tests/travis/build_bootstrap.php
+++ b/tests/travis/build_bootstrap.php
@@ -10,7 +10,7 @@
  * file that was distributed with this source code.
  */
 
-$baseDir = '/home/vagrant/builds/sonata-project/sandbox';
+$baseDir = __DIR__ . '/../..';
 
 require_once $baseDir.'/vendor/symfony/src/Symfony/Component/ClassLoader/UniversalClassLoader.php';
 


### PR DESCRIPTION
Hi,

Seen on http://travis-ci.org/#!/Taluu/sonata-sandbox/builds/1000890 : the bootstrap can't find the UniversalClassLoader because of the hard link for sonata's account on travis.
