### PR TITLE
Fixes the behat tests on the page

### DIFF
--- a/features/backend/page/page.feature
+++ b/features/backend/page/page.feature
@@ -11,12 +11,12 @@ Scenario: Check page admin pages when connected
   Then I should see "Filters"
 
 Scenario: Add a new page with some errors
-  When I am connected with "admin" and "admin" on "admin/sonata/page/page/create?uniqid=4f155592a220e"
+  When I am connected with "admin" and "admin" on "admin/sonata/page/page/create?uniqid=4f155592a220e&siteId=1"
   And I press "Create"
   Then I should see "An error has occurred during item creation."
 
 Scenario: Add a new page
-  When I am connected with "admin" and "admin" on "admin/sonata/page/page/create?uniqid=4f155592a220e"
+  When I am connected with "admin" and "admin" on "admin/sonata/page/page/create?uniqid=4f155592a220e&siteId=1"
   And I fill in "4f155592a220e_name" with "toto"
   And I fill in "4f155592a220e_position" with "1"
   And I select "default" from "4f155592a220e_templateCode"


### PR DESCRIPTION
Hi,

When Behat tries to go to _admin/sonata/page/page/create?uniqid=4f155592a220e_, it is somehow redirected to _admin/sonata/page/page/create?siteId=1_ (or whatever the siteId is by default). The form is then unrecognizable by Behat, and it can't find any fields to fill in the form, because of a different and random hash.

I added an arbitrary siteId to the URL, keeping the good hash to fill in the forms ;but the thing is, it is kind of arbitrary... But it should do the trick if we're only considering a "test environnement" loaded only once by the `php load_data.php`.... ?

**EDIT** : Travis test associated : http://travis-ci.org/#!/Taluu/sonata-sandbox/builds/1001083 (all the page section is now all green), and this should fix #21
