### PR TITLE
Fixes a bug when exporting users to any format

### DIFF
--- a/src/Application/Sonata/UserBundle/Entity/User.php
+++ b/src/Application/Sonata/UserBundle/Entity/User.php
@@ -37,4 +37,14 @@ class User extends BaseUser
     {
         return $this->id;
     }
+    
+    /**
+     * Get Expire date
+     * 
+     * @return  \DateTime|null
+     */
+    public function getExpiresAt()
+    {
+        return $this->expiresAt;
+    }
 }


### PR DESCRIPTION
This should fix a bug when trying to export users from the administration ; the getter for expiresAt was not found, resulting in a 500 error when trying to export, be it in JSON, XML, CSV, Excel, ... etc. 

I added a method getExpiresAt(), but I'm not really sure if it is a fix that is indeed really relevant...
