### PR TITLE
Added "git checkout 2.3".

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,7 @@ Run the following commands::
 
     git clone http://github.com/sonata-project/sandbox.git sonata-sandbox
     cd sonata-sandbox
+    git checkout 2.3
     rm -rf .git
     git init
     git add .gitignore *


### PR DESCRIPTION
Regarding https://github.com/sonata-project/sandbox/issues/71.

The 2.2 build is still broken, however the tutorial works checking out the current (2.3) branch.
