### PR TITLE
Behat tests for ACL

### DIFF
--- a/features/backend/blog/post.feature
+++ b/features/backend/blog/post.feature
@@ -43,7 +43,39 @@ Scenario: View the last revision of a post
   And I follow "Show"
   Then the response status code should be 200
 
-Scenario: Filter posts
+Scenario: Set ACL of a post
+  When I am connected with "admin" and "admin" on "admin/sonata/news/post/list"
+  And I follow "toto"
+  And I follow "ACL"
+  And I check "form_2VIEW"
+  And I check "form_2EDIT"
+  And I press "Update ACL"
+  Then I should see "ACL has been successfuly updated."
+  And the checkbox "form_1OWNER" should be checked
+  And the checkbox "form_2VIEW" should be checked
+  And the checkbox "form_2EDIT" should be checked
+  And the checkbox "form_2DELETE" should not be checked
+  And the checkbox "form_2MASTER" should not be checked
+  And the checkbox "form_1VIEW" should not be checked
+  And the checkbox "form_1EDIT" should not be checked
+  And the checkbox "form_1UNDELETE" should not be checked
+  And the checkbox "form_3EDIT" should not be checked
+
+Scenario: Update ACL of a post
+  When I am connected with "admin" and "admin" on "admin/sonata/news/post/list"
+  And I follow "toto"
+  And I follow "ACL"
+  And I check "form_2DELETE"
+  And I uncheck "form_2EDIT"
+  And I press "Update ACL"
+  Then I should see "ACL has been successfuly updated."
+  And the checkbox "form_2DELETE" should be checked
+  And the checkbox "form_2VIEW" should be checked
+  And the checkbox "form_2EDIT" should not be checked
+  And the checkbox "form_1EDIT" should not be checked
+  And the checkbox "form_3MASTER" should not be checked
+
+  Scenario: Filter posts
   When I am connected with "admin" and "admin" on "admin/sonata/news/post/list"
   And I fill in "filter_title_value" with "toto"
   And I press "Filter"


### PR DESCRIPTION
Retrieve Behat and Mink through Composer instead of using `.phar` files.
Add Behat tests for the ACL editor (scenarios are added to the `blog/post.feature` file).
