### PR TITLE
Add car + non-table inline edit tests

### DIFF
--- a/features/backend/car/car.feature
+++ b/features/backend/car/car.feature
@@ -1,0 +1,64 @@
+@backend
+Feature: Check the car admin module
+
+  Scenario: Check comment admin pages when not connected
+    When I go to "admin/sonata/demo/car/list"
+    Then the response status code should be 200
+    And I should see "Username"
+
+  Scenario: Check car admin pages when connected
+    When I am connected with "admin" and "admin" on "admin/sonata/demo/car/list"
+    Then I should see "Filters"
+
+  Scenario: Add a new car with some errors
+    When I am connected with "admin" and "admin" on "admin/sonata/demo/car/create?subclass=renault&uniqid=f155592a220e"
+    And I press "Create"
+    Then I should see "An error has occurred during item creation."
+
+  Scenario: Add a new car
+    When I am connected with "admin" and "admin" on "admin/sonata/demo/car/create?subclass=renault&uniqid=f155592a220e"
+    And I fill in "Name" with "toto"
+    And I fill in "Date" with "2013-01-01"
+    And I press "Create"
+    Then I should see "Item has been successfully created."
+
+  Scenario: Edit a car
+    When I am connected with "admin" and "admin" on "admin/sonata/demo/car/list"
+    And I follow "toto"
+    And I press "Update"
+    Then I should see "Item has been successfully updated."
+
+  Scenario: Filter cars
+    When I am connected with "admin" and "admin" on "admin/sonata/demo/car/list"
+    And I fill in "filter_name_value" with "toto"
+    And I press "Filter"
+    Then I should see "name"
+
+  Scenario: Export JSON data
+    When I am connected with "admin" and "admin" on "admin/sonata/demo/car/list"
+    And I follow "json"
+    Then the response status code should be 200
+
+  Scenario: Export CSV data
+    When I am connected with "admin" and "admin" on "admin/sonata/demo/car/list"
+    And I follow "csv"
+    Then the response status code should be 200
+
+  Scenario: Export XML data
+    When I am connected with "admin" and "admin" on "admin/sonata/demo/car/list"
+    And I follow "xml"
+    Then the response status code should be 200
+
+  Scenario: Export XLS data
+    When I am connected with "admin" and "admin" on "admin/sonata/demo/car/list"
+    And I follow "xls"
+    Then the response status code should be 200
+
+  Scenario: Delete a car
+    When I am connected with "admin" and "admin" on "admin/sonata/demo/car/list"
+    And I fill in "filter_name_value" with "toto"
+    And I press "Filter"
+    And I follow "toto"
+    And I follow link "Delete" with class "btn btn-danger"
+    And I press "Yes, delete"
+    Then I should see "Item has been deleted successfully."

--- a/src/Sonata/Bundle/DemoBundle/Admin/CarAdmin.php
+++ b/src/Sonata/Bundle/DemoBundle/Admin/CarAdmin.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\Bundle\DemoBundle\Entity\Inspection;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -70,7 +71,20 @@ class CarAdmin extends Admin
             ->add('name')
             ->add('engine', 'sonata_type_model_list')
             ->add('rescueEngine')
+            ->add('inspections', 'sonata_type_collection', array('by_reference' => false), array('edit' => 'inline'))
             ->add('createdAt')
         ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNewInstance()
+    {
+        $object = parent::getNewInstance();
+
+        $object->addInspection(new Inspection());
+
+        return $object;
     }
 }

--- a/src/Sonata/Bundle/DemoBundle/Admin/InspectionAdmin.php
+++ b/src/Sonata/Bundle/DemoBundle/Admin/InspectionAdmin.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Bundle\DemoBundle\Admin;
+
+use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+class InspectionAdmin extends Admin
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureDatagridFilters(DatagridMapper $filter)
+    {
+        $filter
+            ->add('date')
+            ->add('car')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureListFields(ListMapper $list)
+    {
+        $list
+            ->addIdentifier('date')
+            ->add('car')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        if (!$this->hasParentFieldDescription()) {
+            $formMapper->add('car', null, array('constraints' => new Assert\NotNull()));
+        }
+
+        $formMapper->add('date', null, ['widget' => 'single_text']);
+    }
+}

--- a/src/Sonata/Bundle/DemoBundle/Entity/Car.php
+++ b/src/Sonata/Bundle/DemoBundle/Entity/Car.php
@@ -11,7 +11,9 @@
 
 namespace Sonata\Bundle\DemoBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity
@@ -48,6 +50,17 @@ class Car
      * @ORM\ManyToOne(targetEntity="Engine", cascade={"persist"}, fetch="EAGER")
      */
     protected $rescueEngine;
+
+    /**
+     * @ORM\OneToMany(targetEntity="Inspection", cascade={"persist", "remove"}, mappedBy="car")
+     * @Assert\Valid
+     */
+    protected $inspections;
+
+    public function __construct()
+    {
+        $this->inspections = new ArrayCollection();
+    }
 
     public function getId()
     {
@@ -120,5 +133,52 @@ class Car
     public function getRescueEngine()
     {
         return $this->rescueEngine;
+    }
+
+    /**
+     * @param Inspection[] $inspections
+     */
+    public function setInspections($inspections)
+    {
+        $this->inspections->clear();
+
+        foreach ($inspections as $inspection) {
+            $this->addInspection($inspection);
+        }
+    }
+
+    /**
+     * @return Inspection[]
+     */
+    public function getInspections()
+    {
+        return $this->inspections;
+    }
+
+    /**
+     * @param Inspection $inspection
+     * @return void
+     */
+    public function addInspection(Inspection $inspection)
+    {
+        $inspection->setCar($this);
+        $this->inspections->add($inspection);
+    }
+
+    /**
+     * @param Inspection $inspection
+     * @return void
+     */
+    public function removeInspection(Inspection $inspection)
+    {
+        $this->inspections->removeElement($inspection);
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getName() ?: 'n/a';
     }
 }

--- a/src/Sonata/Bundle/DemoBundle/Entity/Inspection.php
+++ b/src/Sonata/Bundle/DemoBundle/Entity/Inspection.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Bundle\DemoBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="test_car_inspection")
+ */
+class Inspection
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Car", inversedBy="inspections")
+     * @ORM\JoinColumn(nullable=false)
+     **/
+    protected $car;
+
+    /**
+     * @ORM\Column(type="date")
+     * @Assert\NotBlank
+     */
+    protected $date;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param Car $car
+     */
+    public function setCar(Car $car)
+    {
+        $this->car = $car;
+    }
+
+    /**
+     * @return Car
+     */
+    public function getCar()
+    {
+        return $this->car;
+    }
+
+    /**
+     * @param $date
+     * @return void
+     */
+    public function setDate($date)
+    {
+        $this->date = $date;
+    }
+
+    /**
+     * @return
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getDate() ? $this->getDate()->format('Y-m-d') : 'n/a';
+    }
+}
+

--- a/src/Sonata/Bundle/DemoBundle/Resources/config/admin.xml
+++ b/src/Sonata/Bundle/DemoBundle/Resources/config/admin.xml
@@ -20,11 +20,20 @@
             </call>
 
         </service>
+
         <service id="sonata.demo.admin.engine" class="Sonata\Bundle\DemoBundle\Admin\EngineAdmin">
             <tag name="sonata.admin" manager_type="orm" group="Demo" label="Engine" />
 
             <argument />
             <argument>Sonata\Bundle\DemoBundle\Entity\Engine</argument>
+            <argument />
+        </service>
+
+        <service id="sonata.demo.admin.inspection" class="Sonata\Bundle\DemoBundle\Admin\InspectionAdmin">
+            <tag name="sonata.admin" manager_type="orm" group="Demo" label="Inspection"/>
+
+            <argument />
+            <argument>Sonata\Bundle\DemoBundle\Entity\Inspection</argument>
             <argument />
         </service>
     </services>


### PR DESCRIPTION
Related to this PR : https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/302

In order to add a non-table inline edit field, I created a new "Inspection" entity, containing a date field. A car can have many inspections.

The car "getNewInstance()" method automatically add an Inspection as we can click the Add button without javascript enabled (as far as I know).

Moreover, I added some tests to the car entity.
