### PR TITLE
fix ACL initialization code block

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Your frontend still looking weird because bundle assets are not installed. Run t
 ACL initialization
 ~~~~~~~~~~~~~~~~~~
 
-The sandbox use the ACL system as security handler. You must init it:
+The sandbox use the ACL system as security handler. You must init it::
 
     app/console init:acl
     app/console sonata:admin:setup-acl


### PR DESCRIPTION
":" was missing to render the three commands as a code block
