### PR TITLE
SONATA-287 - Add a fake newsletter block to sandbox

### DIFF
--- a/app/config/sonata/sonata_block.yml
+++ b/app/config/sonata/sonata_block.yml
@@ -58,3 +58,5 @@ sonata_block:
         sonata.seo.block.twitter.follow_button:
         sonata.seo.block.twitter.hashtag_button:
         sonata.seo.block.twitter.mention_button:
+
+        sonata.demo.block.newsletter:

--- a/src/Sonata/Bundle/DemoBundle/Block/NewsletterBlockService.php
+++ b/src/Sonata/Bundle/DemoBundle/Block/NewsletterBlockService.php
@@ -1,0 +1,120 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Sonata\Bundle\DemoBundle\Block;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Validator\ErrorElement;
+use Sonata\BlockBundle\Block\BaseBlockService;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+
+/**
+ * Class NewsletterBlockService
+ *
+ * Renders a fake newsletter block for the sandbox
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class NewsletterBlockService extends BaseBlockService
+{
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    /**
+     * @var FormInterface
+     */
+    protected $form;
+
+    /**
+     * Constructor
+     *
+     * @param string               $name        A block name
+     * @param EngineInterface      $templating  Twig engine service
+     * @param Request              $request     Symfony Request service
+     * @param FormFactoryInterface $formFactory Symfony FormFactory service
+     * @param string               $formType    Newsletter form type
+     */
+    public function __construct($name, EngineInterface $templating, Request $request, FormFactoryInterface $formFactory, $formType)
+    {
+        parent::__construct($name, $templating);
+
+        $this->request = $request;
+        $this->form    = $formFactory->create($formType);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    {
+        $message = null;
+
+        if ($this->request->isMethod('POST')) {
+            $this->form->handleRequest($this->request);
+
+            if ($this->form->isValid()) {
+                $message = 'Sorry, this is just a demonstration block, it does not really work.';
+            }
+        }
+
+        return $this->renderPrivateResponse($blockContext->getTemplate(), array(
+            'block'   => $blockContext->getBlock(),
+            'context' => $blockContext,
+            'form'    => $this->form->createView(),
+            'message' => $message,
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildEditForm(FormMapper $form, BlockInterface $block)
+    {
+        // no options available
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'template' => 'SonataDemoBundle:Block:newsletter.html.twig',
+            'ttl'      => 0
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'Newsletter Block (fake)';
+    }
+}

--- a/src/Sonata/Bundle/DemoBundle/DependencyInjection/SonataDemoExtension.php
+++ b/src/Sonata/Bundle/DemoBundle/DependencyInjection/SonataDemoExtension.php
@@ -26,6 +26,7 @@ class SonataDemoExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('block.xml');
         $loader->load('form.xml');
         $loader->load('admin.xml');
         $loader->load('products.xml');

--- a/src/Sonata/Bundle/DemoBundle/Form/Type/NewsletterType.php
+++ b/src/Sonata/Bundle/DemoBundle/Form/Type/NewsletterType.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Bundle\DemoBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Class NewsletterType
+ *
+ * This is the newsletter subscription/unsubscription form type
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class NewsletterType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $formBuilder, array $options)
+    {
+        $formBuilder
+            ->add('email', 'email')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sonata_demo_form_type_newsletter';
+    }
+}

--- a/src/Sonata/Bundle/DemoBundle/Resources/config/block.xml
+++ b/src/Sonata/Bundle/DemoBundle/Resources/config/block.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="sonata.demo.block.newsletter" class="Sonata\Bundle\DemoBundle\Block\NewsletterBlockService" public="true" scope="request">
+            <tag name="sonata.block" />
+
+            <argument>sonata.demo.block.newsletter</argument>
+            <argument type="service" id="templating" />
+            <argument type="service" id="request" />
+            <argument type="service" id="form.factory" />
+            <argument>sonata_demo_form_type_newsletter</argument>
+        </service>
+    </services>
+
+</container>

--- a/src/Sonata/Bundle/DemoBundle/Resources/config/form.xml
+++ b/src/Sonata/Bundle/DemoBundle/Resources/config/form.xml
@@ -14,6 +14,10 @@
             <tag name="form.type" alias="sonata_demo_form_type_engine" />
         </service>
 
+        <service id="sonata.demo.form.type.newsletter" class="Sonata\Bundle\DemoBundle\Form\Type\NewsletterType">
+            <tag name="form.type" alias="sonata_demo_form_type_newsletter" />
+        </service>
+
         <service id="sonata.demo.form.type.advanced_rescue_engine" class="Sonata\Bundle\DemoBundle\Form\Extension\RescueEngineTypeExtension">
              <tag name="form.type_extension" alias="sonata_demo_car" />
         </service>

--- a/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
+++ b/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
@@ -2,10 +2,25 @@
     text-align: right !important;
 }
 
-.sonata-bc .page-footer {
+.sonata-bc .block-newsletter {
     background-color: #f5f5f5;
     padding: 20px 20px 10px;
     margin: -20px -20px 20px;
+}
+
+.sonata-bc .block-newsletter input[type="email"] {
+    margin-bottom: 0px;
+}
+
+.sonata-bc .block-newsletter p {
+    font-size: 14px;
+    font-weight: bold;
+}
+
+.sonata-bc .page-footer {
+    background-color: #dedede;
+    padding: 20px 20px 10px;
+    margin: -40px -20px 20px;
 }
 
 .sonata-bc .page-footer ul li {

--- a/src/Sonata/Bundle/DemoBundle/Resources/views/Block/newsletter.html.twig
+++ b/src/Sonata/Bundle/DemoBundle/Resources/views/Block/newsletter.html.twig
@@ -1,0 +1,21 @@
+<div class="row-fluid block-newsletter">
+    <div class="span12" style="text-align: center;">
+        <p>Want to stay in touch with us?</p>
+        <p>Subscribe to our monthly newsletter.</p>
+
+        <div>
+            <form id="newsletter-form" name="newsletter-form" method="post" action="">
+                {{ form_label(form.email) }}
+                {{ form_widget(form.email) }}
+
+                {{ form_rest(form) }}
+
+                <input class="btn" type="submit" value="Subscribe" />
+            </form>
+        </div>
+
+        {% if message %}
+            <div class="alert alert-error">{{ message }}</div>
+        {% endif %}
+    </div>
+</div>


### PR DESCRIPTION
I've added the footer fake newsletter block.

When filled, it returns the following error message: "Sorry, this is just a demonstration block, it does not really work."
