### PR TITLE
SONATA-308 - Add product properties templates for modal

### DIFF
--- a/src/Application/Sonata/ProductBundle/Provider/TrainingProductProvider.php
+++ b/src/Application/Sonata/ProductBundle/Provider/TrainingProductProvider.php
@@ -10,7 +10,10 @@
 
 namespace Application\Sonata\ProductBundle\Provider;
 
+use JMS\Serializer\SerializerInterface;
+
 use Application\Sonata\ProductBundle\Entity\Training;
+
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\ProductBundle\Model\BaseProductProvider;
 
@@ -26,6 +29,20 @@ use Sonata\ProductBundle\Model\BaseProductProvider;
  */
 class TrainingProductProvider extends BaseProductProvider
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(SerializerInterface $serializer)
+    {
+        $this->serializer = $serializer;
+        $this->setOptions(array(
+            'product_add_modal' => true
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getBaseControllerName()
     {
         return 'SonataProductBundle:Training';

--- a/src/Application/Sonata/ProductBundle/Resources/views/Goodie/properties.html.twig
+++ b/src/Application/Sonata/ProductBundle/Resources/views/Goodie/properties.html.twig
@@ -1,0 +1,10 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}

--- a/src/Application/Sonata/ProductBundle/Resources/views/Training/properties.html.twig
+++ b/src/Application/Sonata/ProductBundle/Resources/views/Training/properties.html.twig
@@ -1,0 +1,25 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+<dl class="dl-horizontal" style="margin-bottom: 0;">
+    {% if not product.isMaster %}
+        <dt style="width: auto;">{{ 'training.level_title'|trans([], 'SonataProductBundle') }}</dt>
+        <dd style="margin-left: 110px;">{{ product.level|trans([], 'SonataProductBundle') }}</dd>
+        <dt style="width: auto;">{{ 'training.instructor_title'|trans([], 'SonataProductBundle') }}</dt>
+        <dd style="margin-left: 110px;">{{ product.instructorName|trans([], 'SonataProductBundle') }}</dd>
+        {% if product.startDate %}
+            <dt style="width: auto;">{{ 'training.start_date_title'|trans([], 'SonataProductBundle') }}</dt>
+            <dd style="margin-left: 110px;">{{ product.startDate|date() }}</dd>
+        {% endif %}
+        <dt style="width: auto;">{{ 'training.duration_title'|trans([], 'SonataProductBundle') }}</dt>
+        <dd style="margin-left: 110px;">{{ product.duration|trans([], 'SonataProductBundle') }}</dd>
+    {% endif %}
+</dl>


### PR DESCRIPTION
Add demonstration Training & Goodie product types properties templates (used to be rendered in "Add to basket" new Bootstrap modal).

These templates renders variation product type informations.

This PR requires the following PR to be merged: https://github.com/sonata-project/ecommerce/pull/38
