### PR TITLE
Remove sonata product user class configuration node

### DIFF
--- a/app/config/sonata/sonata_product.yml
+++ b/app/config/sonata/sonata_product.yml
@@ -12,9 +12,6 @@ sonata_product:
             variations:
                 fields: [name, level, instructor_name, start_date, duration, price]
 
-    class:
-        user: Application\Sonata\Userbundle\Entity\User # you must define your own user class
-
     seo:
         product:
             site: '@sonataproject'


### PR DESCRIPTION
Remove unusued configuration node.

**Warning**: This should be merged once https://github.com/sonata-project/ecommerce/pull/51 is merged.
