### PR TITLE
SONATA-334 - Fix sandbox CSS for recent & similar products blocks

### DIFF
--- a/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
+++ b/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
@@ -64,7 +64,7 @@
     text-align: center;
 }
 .product-grid .col-sm-3 {
-    height: 175px;
+    min-height: 175px;
     padding-right: 15px;
     padding-left: 15px;
 }


### PR DESCRIPTION
I've fixed height to be a minimal height in products list blocks
