### PR TITLE
SONATA-347 - Move newsletter to left side in order to add Twitter block ...

### DIFF
--- a/src/Sonata/Bundle/DemoBundle/DataFixtures/ORM/LoadPageData.php
+++ b/src/Sonata/Bundle/DemoBundle/DataFixtures/ORM/LoadPageData.php
@@ -257,15 +257,38 @@ CONTENT
         $newProductsBlock->setEnabled(true);
         $newProductsBlock->setPage($homepage);
 
+        // Add homepage bottom container
         $homepage->addBlocks($bottom = $blockInteractor->createNewContainer(array(
             'enabled' => true,
             'page'    => $homepage,
             'code'    => 'content_bottom',
-        )));
+        ), function ($container) {
+            $container->setSetting('layout', '<div class="block-newsletter">{{ CONTENT }}</div>');
+        }));
         $bottom->setName('The bottom content container');
 
-        // Homepage footer newsletter block
-        $bottom->addChildren($newsletter = $blockManager->create());
+        // Add homepage bottom left container
+        $bottom->addChildren($bottomLeft = $blockInteractor->createNewContainer(array(
+            'enabled' => true,
+            'page'    => $homepage,
+            'code'    => 'content_bottom_left',
+        ), function ($container) {
+            $container->setSetting('layout', '<div class="col-sm-6 well">{{ CONTENT }}</div>');
+        }));
+        $bottomLeft->setName('The bottom left content container');
+
+        // Add homepage bottom right container
+        $bottom->addChildren($bottomRight = $blockInteractor->createNewContainer(array(
+            'enabled' => true,
+            'page'    => $homepage,
+            'code'    => 'content_bottom_right',
+        ), function ($container) {
+            $container->setSetting('layout', '<div class="col-sm-6 well">{{ CONTENT }}</div>');
+        }));
+        $bottomLeft->setName('The bottom right content container');
+
+        // Add homepage bottom newsletter (left) & twitter (right) blocks
+        $bottomLeft->addChildren($newsletter = $blockManager->create());
 
         $newsletter->setType('sonata.demo.block.newsletter');
         $newsletter->setPosition(1);

--- a/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
+++ b/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
@@ -7,6 +7,10 @@
     margin-top: 10px;
 }
 
+.sonata-bc .block-newsletter > div.col-sm-6 {
+    min-height: 155px;
+}
+
 .sonata-bc .block-newsletter input[type="email"] {
     margin-bottom: 0px;
 }

--- a/src/Sonata/Bundle/DemoBundle/Resources/views/Block/newsletter.html.twig
+++ b/src/Sonata/Bundle/DemoBundle/Resources/views/Block/newsletter.html.twig
@@ -1,19 +1,21 @@
-<div class="col-md-12 block-newsletter well">
+<div>
     <p>Want to stay in touch with us?</p>
     <p>Subscribe to our monthly newsletter.</p>
 
-    <div class="row">
-        <form id="newsletter-form" name="newsletter-form" method="post" action="{{ path('sonata_demo_newsletter') }}" data-name="sonata-ajax" data-target="newsletter_confirmation" class="form-inline">
-            {{ form_row(form.email, {'label_attr': {'class': 'sr-only'}, 'horizontal_input_wrapper_class': 'col-lg-12'}) }}
+    <form id="newsletter-form" name="newsletter-form" method="post" action="{{ path('sonata_demo_newsletter') }}" data-name="sonata-ajax" data-target="newsletter_confirmation" class="form-inline">
+        <div class="col-sm-6 col-sm-offset-1">
+            {{ form_widget(form.email, {'horizontal_input_wrapper_class': 'col-lg-12'}) }}
+        </div>
 
-            {{ form_rest(form) }}
-
+        <div class="col-sm-3">
             <button class="btn btn-default" type="submit"><i class="glyphicon glyphicon-envelope"></i>&nbsp; Subscribe</button>
-        </form>
-    </div>
+        </div>
+
+        {{ form_rest(form) }}
+    </form>
     &nbsp;
     <div class="row">
-        <div class="col-lg-6 col-lg-offset-3">
+        <div class="col-lg-12">
             <div id="newsletter_confirmation"></div>
         </div>
     </div>

--- a/src/Sonata/Bundle/DemoBundle/Resources/views/Block/newsletter_confirmation.html.twig
+++ b/src/Sonata/Bundle/DemoBundle/Resources/views/Block/newsletter_confirmation.html.twig
@@ -1,1 +1,1 @@
-<div class="alert alert-danger">{{ message }}</div>
+<div class="alert alert-success">{{ message }}</div>


### PR DESCRIPTION
...at right

I've move the newsletter block into the left side in order to add the Twitter block on the right side once it will be available.

I've also set the `mopa_bootstrap.form.templating` parameter to `false` because it was decorating all forms by default.
