### PR TITLE
SONATA-384 - Improve header login/register and basket

### DIFF
--- a/src/Sonata/Bundle/DemoBundle/DataFixtures/ORM/LoadPageData.php
+++ b/src/Sonata/Bundle/DemoBundle/DataFixtures/ORM/LoadPageData.php
@@ -172,7 +172,7 @@ class LoadPageData extends AbstractFixture implements ContainerAwareInterface, O
 
 <h1>Gallery List</h1>
 CONTENT
-);
+        );
         $text->setPosition(1);
         $text->setEnabled(true);
         $text->setPage($galleryIndex);
@@ -231,7 +231,7 @@ CONTENT
     </p>
 </div>
 CONTENT
-);
+        );
         $text->setPosition(1);
         $text->setEnabled(true);
         $text->setPage($homepage);
@@ -646,22 +646,45 @@ CONTENT
 
         $header->setName('The header container');
 
-        $header->addChildren($account = $blockManager->create());
+        $global->addBlocks($headerTop = $blockInteractor->createNewContainer(array(
+            'enabled' => true,
+            'page' => $global,
+            'code' => 'header-top',
+        ), function ($container) {
+            $container->setSetting('layout', '<div class="pull-right">{{ CONTENT }}</div>');
+        }));
+
+        $headerTop->setPosition(1);
+
+        $header->addChildren($headerTop);
+
+        $headerTop->addChildren($account = $blockManager->create());
 
         $account->setType('sonata.user.block.account');
         $account->setPosition(1);
         $account->setEnabled(true);
         $account->setPage($global);
 
-        $header->addChildren($basket = $blockManager->create());
+        $headerTop->addChildren($basket = $blockManager->create());
 
         $basket->setType('sonata.basket.block.nb_items');
         $basket->setPosition(2);
         $basket->setEnabled(true);
         $basket->setPage($global);
 
+        $global->addBlocks($headerMenu = $blockInteractor->createNewContainer(array(
+            'enabled' => true,
+            'page' => $global,
+            'code' => 'header-menu',
+        )));
 
-        $header->addChildren($menu = $blockManager->create());
+        $headerMenu->setPosition(2);
+
+        $header->addChildren($headerMenu);
+
+        $headerMenu->setName('The header menu container');
+        $headerMenu->setPosition(3);
+        $headerMenu->addChildren($menu = $blockManager->create());
 
         $menu->setType('sonata.block.service.menu');
         $menu->setSetting('menu_name', "SonataDemoBundle:Builder:mainMenu");

--- a/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
+++ b/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
@@ -73,7 +73,7 @@
     font-size: 1em;
 }
 
-.sonata-bc .add_basket_modal {
+.sonata-bc #add_basket_modal {
     top: 15%;
 }
 


### PR DESCRIPTION
Header has been improved with the mini-basket information on the same line of login/register menu:

![capture decran 2014-01-17 a 16 14 41](https://f.cloud.github.com/assets/103900/1941421/2285f104-7f8a-11e3-945c-38dd3ccb9900.png)
