### PR TITLE
SONATA-382 - Update security.yml to do not invalidate session on logout

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -53,7 +53,11 @@ security:
                 use_forward:    false
                 check_path:     /login_check
                 failure_path:   null
-            logout:       true
+            logout:
+                path: /logout
+                # We set invalidate_session to false because we want basket
+                # to be fully persisted even when user logout and login again
+                invalidate_session: false
             anonymous:    true
 
     access_control:


### PR DESCRIPTION
I've fixed security configuration for main (frontend) firewall to do not invalidate session on user logout because we want to keep it's basket persisted.
