### PR TITLE
Fix CSS form address creation/edition save button

### DIFF
--- a/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
+++ b/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
@@ -66,6 +66,10 @@
     content: "\00BB";
 }
 
+form .form-actions {
+    min-height: 48px;
+}
+
 /*
  * Basket
  */


### PR DESCRIPTION
I've fixed "Save your address" button alignment.

![capture decran 2014-01-22 a 11 35 38](https://f.cloud.github.com/assets/103900/1972937/0409e77e-8351-11e3-955c-436988e0cc68.png)
