### PR TITLE
Fix travels variation fields configuration

### DIFF
--- a/app/config/sonata/sonata_product.yml
+++ b/app/config/sonata/sonata_product.yml
@@ -10,7 +10,7 @@ sonata_product:
             provider: sonata.ecommerce_demo.product.travel.type
             manager: sonata.ecommerce_demo.product.travel.manager
             variations:
-                fields: [travellers, travelDays]
+                fields: [travellers, travelDays, name, price, stock, vatRate, priceIncludingVat, enabled]
 
     seo:
         product:


### PR DESCRIPTION
I've fixed some missing variation fields for `Travel` product types to do not be overriden on saving parent product.

This is linked to the ecommerce PR https://github.com/sonata-project/ecommerce/pull/121 that adds `sku` field to unique attributes.
