### PR TITLE
Fix sonata bootstraping Kernel requirement

### DIFF
--- a/app/console
+++ b/app/console
@@ -22,7 +22,7 @@ if (count($_SERVER['argv']) > 1) {
     $name = $_SERVER['argv'][1];
     $kernelClass = ucfirst($name).'Kernel';
 
-    if (!is_file(__DIR__.'/'.ucfirst($name).'/'.$kernelClass.'.php')) {
+    if (!is_file(__DIR__.'/'.strtolower($name).'/'.$kernelClass.'.php')) {
         $name = $kernelClass = false;
     } else {
         unset($_SERVER['argv'][1]); // remove the app name from the argv
@@ -46,7 +46,7 @@ if ($debug) {
     Debug::enable();
 }
 
-include_once __DIR__.'/'.ucfirst($name).'/'.$kernelClass.'.php';
+include_once __DIR__.'/'.strtolower($name).'/'.$kernelClass.'.php';
 $kernel = new $kernelClass($env, $debug);
 
 $application = new Application($kernel);

--- a/web/bootstrap.php
+++ b/web/bootstrap.php
@@ -48,7 +48,7 @@ function sonata_bootstrap($name, $env, $debug) {
 
     $className = ucfirst($name).'Kernel';
 
-    require_once __DIR__.'/../app/'.$name.'/'.$className.'.php';
+    require_once __DIR__.'/../app/'.strtolower($name).'/'.$className.'.php';
 
     $kernel = new $className($env, $debug);
 


### PR DESCRIPTION
We have the following error on Jenkins integration platform:

```
PHP Warning:  include_once(/data/www/<integ>/app/Admin/AdminKernel.php): failed to open stream: No such file or directory in /data/www/<integ>/app/console on line 48
```

I think this is because `app/console` try to require a non-lower named directory in `app` directory.

This should fix the problem.
