### PR TITLE
SONATA-419 - Add product thumbnails grid margin

### DIFF
--- a/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
+++ b/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
@@ -214,6 +214,11 @@ div#slider-thumbs ul.list-inline {
     width: 620px;
 }
 
+div#slider-thumbs ul li {
+    padding-left: 0px;
+    margin-bottom: 10px;
+}
+
 /*
  * News
  */


### PR DESCRIPTION
I've fixed CSS to add a margin between thumbnails:

![capture decran 2014-02-04 a 15 29 25](https://f.cloud.github.com/assets/103900/2076804/ce864414-8da8-11e3-802a-f0d842500968.png)
