### PR TITLE
SONATA-427 - Fix products final review templates + add login stepper

### DIFF
--- a/src/Application/Sonata/ProductBundle/Resources/views/Goodie/final_review_basket_element.html.twig
+++ b/src/Application/Sonata/ProductBundle/Resources/views/Goodie/final_review_basket_element.html.twig
@@ -17,11 +17,6 @@ file that was distributed with this source code.
 
 {% extends 'SonataProductBundle:Product:final_review_basket_element.html.twig' %}
 
-{% block product_description %}
-    <b>{{ basketElement.name }}</b> <br />
-    {{ basketElement.product.description|raw }}
-{% endblock %}
-
 {#
 {% block product_unit_price %}
     {{ basketElement.getUnitPrice(true)|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}

--- a/src/Application/Sonata/ProductBundle/Resources/views/Travel/final_review_basket_element.html.twig
+++ b/src/Application/Sonata/ProductBundle/Resources/views/Travel/final_review_basket_element.html.twig
@@ -17,11 +17,6 @@ file that was distributed with this source code.
 
 {% extends 'SonataProductBundle:Product:final_review_basket_element.html.twig' %}
 
-{% block product_description %}
-    <b>{{ basketElement.name }}</b> <br />
-    {{ basketElement.product.description|raw }}
-{% endblock %}
-
 {#
 {% block product_unit_price %}
     {{ basketElement.getUnitPrice(true)|number_format_currency(basket.currency.label, {}, {}, basket.locale) }}

--- a/src/Application/Sonata/UserBundle/Resources/views/Security/login.html.twig
+++ b/src/Application/Sonata/UserBundle/Resources/views/Security/login.html.twig
@@ -1,0 +1,20 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends "SonataUserBundle:Security:base_login.html.twig" %}
+
+{% block fos_user_content %}
+    {% if app.request.session.get('sonata_basket_delivery_redirect') %}
+        {% include 'SonataBasketBundle:Basket:stepper.html.twig' with {step: 'identification'} %}
+    {% endif %}
+
+    {{ parent() }}
+{% endblock fos_user_content %}

--- a/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
+++ b/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
@@ -73,6 +73,10 @@
     content: "\00BB";
 }
 
+form div.alert ~ .form-actions {
+    min-height: 54px;
+}
+
 form .form-actions {
     min-height: 48px;
 }


### PR DESCRIPTION
I've updated products templates and added login template into sandbox to add checkout stepper when needed.

Stepper looks like this:

![capture decran 2014-02-05 a 14 15 58](https://f.cloud.github.com/assets/103900/2087216/b8d270d8-8e67-11e3-8cf1-27cedcb9854d.png)

This is related to ecommerce PR https://github.com/sonata-project/ecommerce/pull/134
