### PR TITLE
SONATA-428 - Add missing media admin route

### DIFF
--- a/app/admin/config/routing.yml
+++ b/app/admin/config/routing.yml
@@ -14,3 +14,7 @@ soanata_user_admin:
 sonata_media_pixlr:
     resource: '@SonataMediaBundle/Resources/config/routing/pixlr.xml'
     prefix:   /admin/media
+
+sonata_media_media:
+    resource: '@SonataMediaBundle/Resources/config/routing/media.xml'
+    prefix: /media


### PR DESCRIPTION
This media admin routing was missing in the AdminKernel routing file (`admin/routing.yml`) so I've added it.
