### PR TITLE
Implemented SonataNotificationBundle's API & fixed routing for NewsBundle

### DIFF
--- a/app/api/config/routing.yml
+++ b/app/api/config/routing.yml
@@ -7,7 +7,16 @@ sonata_api_news:
     prefix:       /api/news
     resource:     "@SonataNewsBundle/Resources/config/routing/api.xml"
 
+blog:
+    resource: '@SonataNewsBundle/Resources/config/routing/news.xml'
+    prefix: /blog
+
 sonata_api_media:
     type:         rest
     prefix:       /api/media
     resource:     "@SonataMediaBundle/Resources/config/routing/api.xml"
+
+sonata_api_notification:
+    type:         rest
+    prefix:       /api/notification
+    resource:     "@SonataNotificationBundle/Resources/config/routing/api.xml"


### PR DESCRIPTION
Requires https://github.com/sonata-project/SonataNewsBundle/pull/166 to be merged before
