### PR TITLE
Update page fixtures for new header

### DIFF
--- a/src/Sonata/Bundle/DemoBundle/DataFixtures/ORM/LoadPageData.php
+++ b/src/Sonata/Bundle/DemoBundle/DataFixtures/ORM/LoadPageData.php
@@ -986,22 +986,6 @@ CONTENT
         $pageManager->save($global);
 
         // CREATE A HEADER BLOCK
-        $global->addBlocks($title = $blockInteractor->createNewContainer(array(
-            'enabled' => true,
-            'page' => $global,
-            'code' => 'title',
-        )));
-
-        $title->setName('The title container');
-
-        $title->addChildren($text = $blockManager->create());
-
-        $text->setType('sonata.block.service.text');
-        $text->setSetting('content', '<h2><a href="/">Sonata Demo</a></h2>');
-        $text->setPosition(1);
-        $text->setEnabled(true);
-        $text->setPage($global);
-
         $global->addBlocks($header = $blockInteractor->createNewContainer(array(
             'enabled' => true,
             'page' => $global,
@@ -1009,6 +993,14 @@ CONTENT
         )));
 
         $header->setName('The header container');
+
+        $header->addChildren($text = $blockManager->create());
+
+        $text->setType('sonata.block.service.text');
+        $text->setSetting('content', '<h2><a href="/">Sonata Demo</a></h2>');
+        $text->setPosition(1);
+        $text->setEnabled(true);
+        $text->setPage($global);
 
         $global->addBlocks($headerTop = $blockInteractor->createNewContainer(array(
             'enabled' => true,

--- a/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
+++ b/src/Sonata/Bundle/DemoBundle/Resources/public/css/demo.css
@@ -13,6 +13,9 @@
 /*
  * Sonata Demo
  */
+div .page-header h2 {
+    display: inline;
+}
 
 @media screen and (min-width: 1200px) {
     .sonata-bc .container {


### PR DESCRIPTION
I've updated fixtures to have new header organized like this:

![capture decran 2014-02-19 a 14 03 01](https://f.cloud.github.com/assets/103900/2206668/7b18b5ea-9966-11e3-850b-6056db8ce6cf.png)

The following PR must be merged: https://github.com/sonata-project/SonataPageBundle/pull/292
