### PR TITLE
Add missing SonataCommentBundle configuration

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -27,6 +27,7 @@ imports:
 
     # Sonata Feature Bundles
     - { resource: sonata/sonata_admin.yml }
+    - { resource: sonata/sonata_comment.yml }
     - { resource: sonata/sonata_page.yml }
     - { resource: sonata/sonata_media.yml }
     - { resource: sonata/sonata_news.yml }

--- a/app/config/sonata/sonata_comment.yml
+++ b/app/config/sonata/sonata_comment.yml
@@ -1,0 +1,8 @@
+#
+# more information can be found here http://sonata-project.org/bundles/comment
+#
+sonata_comment:
+    manager_type: orm # can be 'orm' or 'mongodb'
+    class:
+        comment: Application\Sonata\CommentBundle\Entity\Comment # This is an optional value
+        thread: Application\Sonata\CommentBundle\Entity\Thread   # This is an optional value


### PR DESCRIPTION
I've added missing default configuration in order to be accessed more easily by sandbox users
