### PR TITLE
SONATA-463 - Update news fixtures author from 'secure' to 'johndoe'

### DIFF
--- a/src/Sonata/Bundle/DemoBundle/DataFixtures/ORM/LoadNewsData.php
+++ b/src/Sonata/Bundle/DemoBundle/DataFixtures/ORM/LoadNewsData.php
@@ -65,7 +65,7 @@ class LoadNewsData extends AbstractFixture implements ContainerAwareInterface, O
 
         foreach (range(1, 20) as $id) {
             $post = $postManager->create();
-            $post->setAuthor($this->getReference('user-admin'));
+            $post->setAuthor($this->getReference('user-johndoe'));
 
             $post->setCollection($collection);
             $post->setAbstract($faker->sentence(30));


### PR DESCRIPTION
I've updated news author fixtures to be "johndoe"
