### PR TITLE
Override registration template to adapt responsive classes

### DIFF
--- a/app/config/mopa/mopa_bootstrap.yml
+++ b/app/config/mopa/mopa_bootstrap.yml
@@ -3,4 +3,7 @@ mopa_bootstrap:
         show_legend: false
         render_optional_text: false
         render_required_asterisk: true
+        horizontal_label_class: col-sm-3 control-label
+        horizontal_label_offset_class: col-sm-offset-3
+        horizontal_input_wrapper_class: col-sm-9 control-label
 #    menu: ~  # enables twig helpers for menu

--- a/src/Application/Sonata/UserBundle/Resources/views/Registration/register_content.html.twig
+++ b/src/Application/Sonata/UserBundle/Resources/views/Registration/register_content.html.twig
@@ -1,0 +1,32 @@
+<div class="panel panel-success">
+    <div class="panel-heading">
+        <h2 class="panel-title">{{ 'title_user_registration'|trans({}, 'SonataUserBundle') }}</h2>
+    </div>
+    <div class="panel-body">
+        <form action="{{ path('fos_user_registration_register') }}" {{ form_enctype(form) }} method="POST" class="fos_user_registration_register form-horizontal">
+
+            <div class="form-group">
+                {{ form_label(form.username, null, {'label_attr': {'class': 'col-sm-4'}}) }}
+                {{ form_widget(form.username, {'horizontal_input_wrapper_class': 'col-sm-8', 'horizontal_label_class': 'col-sm-4'}) }}
+            </div>
+
+            <div class="form-group">
+                {{ form_label(form.email, null, {'label_attr': {'class': 'col-sm-4'}}) }}
+                {{ form_widget(form.email, {'horizontal_input_wrapper_class': 'col-sm-8', 'horizontal_label_class': 'col-sm-4'}) }}
+            </div>
+
+            {% for passwordField in form.plainPassword %}
+                <div class="form-group">
+                    {{ form_label(passwordField, null, {'label_attr': {'class': 'col-sm-4'}}) }}
+                    {{ form_widget(passwordField, {'horizontal_input_wrapper_class': 'col-sm-8', 'horizontal_label_class': 'col-sm-4'}) }}
+                </div>
+            {% endfor %}
+
+            {{ form_rest(form) }}
+
+            <div class="form-actions">
+                <input type="submit" value="{{ 'registration.submit'|trans({}, 'FOSUserBundle') }}" class="btn btn-success pull-right" />
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/Sonata/Bundle/DemoBundle/DataFixtures/ORM/LoadPageData.php
+++ b/src/Sonata/Bundle/DemoBundle/DataFixtures/ORM/LoadPageData.php
@@ -265,8 +265,8 @@ CONTENT
         $contentTop->addChildren($text = $blockManager->create());
         $text->setType('sonata.block.service.text');
         $text->setSetting('content', <<<CONTENT
-<div class="col-md-3 welcome"><h2>Welcome</h2></div>
-<div class="col-md-9">
+<div class="col-sm-3 welcome"><h2>Welcome</h2></div>
+<div class="col-sm-9">
     <p>
         This page is a demo of the Sonata Sandbox available on <a href="https://github.com/sonata-project/sandbox">github</a>.
         This demo try to be interactive so you will be able to found out the different features provided by the Sonata's Bundle.


### PR DESCRIPTION
This registration template has been overriden in the sandbox in order to have a well responsive behavior.

This is related to PR https://github.com/sonata-project/SonataUserBundle/pull/383