### PR TITLE
Update composer.json for missing markitup-bundle install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,8 @@
         "stephpy/TimelineBundle": "~2.0@dev",
         "stephpy/timeline": "~1.0@dev",
 
-        "incenteev/composer-parameter-handler": "~2.0"
+        "incenteev/composer-parameter-handler": "~2.0",
+        "sonata-project/markitup-bundle": "~2.1"
     },
 
     "require-dev": {


### PR DESCRIPTION
It looks that in AppKernel.php on line 62 you call 
new Sonata\MarkItUpBundle\SonataMarkItUpBundle(),
which is not even installed when you first 
php composer.phar create-project sonata-project/sandbox:2.3.x-dev
