### PR TITLE
Update AppKernel.php

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -8,12 +8,12 @@ class AppKernel extends Kernel
     /**
      * {@inheritdoc}
      */
-    public function init()
+    public function __construct($environment, $debug)
     {
         // Please read http://symfony.com/doc/2.0/book/installation.html#configuration-and-setup
         bcscale(3);
 
-        parent::init();
+        parent::__construct($environment, $debug);
     }
 
     /**


### PR DESCRIPTION
Deprecated: Calling the AppKernel::init() method is deprecated since version 2.3 and will be removed in 3.0. Move your logic to the constructor method instead. 