### PR TITLE
Error composer update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,13 +39,13 @@
         "symfony-cmf/routing-bundle": "~1.1",
 
         "knplabs/gaufrette": "~0.1.6",
-        "knplabs/knp-menu-bundle": "~2.0",
+        "knplabs/knp-menu-bundle": "dev-master",
 
         "sonata-project/easy-extends-bundle": "~2.1@dev",
         "sonata-project/seo-bundle": "~2.0",
         "sonata-project/doctrine-extensions": "~1@dev",
         "sonata-project/intl-bundle": "~2.2@dev",
-        "sonata-project/admin-bundle": "~2.4@dev",
+        "sonata-project/admin-bundle": "dev-master",
         "sonata-project/doctrine-orm-admin-bundle": "~2.4@dev",
         "sonata-project/notification-bundle": "~2.2@dev",
         "sonata-project/block-bundle": "~2.3@dev",


### PR DESCRIPTION
Problem 1
    - remove sonata-project/admin-bundle 2.4.x-dev|keep sonata-project/admin-bundle dev-master
    - sonata-project/admin-bundle 2.4.x-dev requires knplabs/knp-menu-bundle dev-master -> no matching package found.
    - sonata-project/admin-bundle dev-master requires knplabs/knp-menu-bundle dev-master -> no matching package found.
    - Installation request for sonata-project/admin-bundle ~2.4@dev -> satisfiable by sonata-project/admin-bundle[2.4.x-dev].

These changes correct the problem.