### PR TITLE
fix composer create-project branch develop [v2.4]

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Get composer:
 
 Run the following command for the 2.4 develop branch:
 
-    php composer.phar create-project sonata-project/sandbox:2.4.x-dev
+    php composer.phar create-project sonata-project/sandbox:dev-2.4-develop 
 
 The installation process used Incenteev's ParameterHandler to handle parameters.yml configuration. With the current
 installation, it is possible to use environment variables to configure this file:


### PR DESCRIPTION
correct in the get started page : https://www.sonata-project.org/get-started

But with : composer create-project sonata-project/sandbox:2.4.x-dev 
README.md
gives:
[InvalidArgumentException]
Could not find package sonata-project/sandbox with version 2.4.x-dev.