### PR TITLE
FIX: remove the double quotes around the encoders

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -3,12 +3,12 @@ parameters:
 
 security:
     encoders:
-        "Application\Sonata\UserBundle\Entity\User":
+        Application\Sonata\UserBundle\Entity\User:
             algorithm: sha512
             encode_as_base64: false
             iterations: 1
 
-        "Symfony\Component\Security\Core\User\User": plaintext
+        Symfony\Component\Security\Core\User\User: plaintext
 
     role_hierarchy:
         ROLE_ADMIN:       ROLE_USER


### PR DESCRIPTION
Hello

I tried to install the sonata project and when I run this command: 
`php app/console fos:user:create --super-admin admin adm in@domain.com PASSWORD`

I always had this error : 
```
[RuntimeException]
  No encoder has been configured for account "Application\Sonata\UserBundle\Entity\User".
```

We need to remove the double quotes around the encoder's class

@rande 