### PR TITLE
Fix issue with switch user in dashboard

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -75,6 +75,7 @@ security:
                 invalidate_session: false
                 handlers: ['sonata.page.cms_manager_selector', 'sonata.basket.factory']
             anonymous:    true
+            switch_user: true
 
     access_control:
         # URL of FOSUserBundle which need to be available to anonymous users


### PR DESCRIPTION
I had a problem with the switch user in Sonata Sandbox. After viewing the configuration files, I found lacking parameter `firewall.yml`