### PR TITLE
Direct publication

### DIFF
--- a/app/config/sonata/sonata_page.yml
+++ b/app/config/sonata/sonata_page.yml
@@ -11,6 +11,7 @@ cmf_routing:
             router.default: 100
 
 sonata_page:
+    direct_publication:    %kernel.debug% # if you want to publish in dev mode (but not in prod)
     multisite:             host_with_path # host
     use_streamed_response: false # set the value to false in debug mode or if the reverse proxy does not handle streamed response
 


### PR DESCRIPTION
In the sandbox demo the direct publication is enabled.

I lost several hours to know why my pages' urls were not generated. So I think the demo and the repository should have the exactly same configuration.