### PR TITLE
Update Vagrant build

### DIFF
--- a/.ansible/install_requirements.sh
+++ b/.ansible/install_requirements.sh
@@ -42,7 +42,7 @@ if [ ! -d /var/www/sonata-sandbox ]; then
 fi
 
 if [ ! -d /var/www/sonata-sandbox/vendor ]; then
-    composer install
+    cd /var/www/sonata-sandbox && composer install
 fi
 
 if [ ! -f /var/www/sonata-sandbox/app/config/parameters.yml ]; then

--- a/.ansible/roles/init/tasks/main.yml
+++ b/.ansible/roles/init/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: Install Extra Packages
   sudo: yes
   apt: pkg={{ item }} state=latest
-  with_items: sys_packages
+  with_items: "{{ sys_packages }}"
 
 - name: Configure the timezone
   sudo: yes

--- a/.ansible/roles/phpcommon/tasks/main.yml
+++ b/.ansible/roles/phpcommon/tasks/main.yml
@@ -1,4 +1,4 @@
 - name: Install PHP Packages
   sudo: yes
   apt: pkg={{ item }} state=latest
-  with_items: php_packages
+  with_items: "{{ php_packages }}"

--- a/.ansible/vars/common.yml
+++ b/.ansible/vars/common.yml
@@ -1,5 +1,5 @@
 ---
-    php_ppa: php5-5.6
+    php_ppa: php
     doc_root: /vagrant
     sys_packages: ["vim","git","htop","iotop","imagemagick", "openjdk-7-jre"]
     dist: precise


### PR DESCRIPTION
This PR fix Vagrant build.

- update php ppa repo to follow new repo structure (see: https://github.com/phansible/phansible/issues/289)
```
==> default: TASK [init : Add ppa Repository] ***********************************************
==> default: fatal: [192.168.33.99]: FAILED! => {"changed": false, "failed": true, "msg": "failed to fetch PPA information, error was: HTTP Error 404: Not Found"}
```

- fix Ansible syntax
```
==> default: TASK [init : Install Extra Packages] *******************************************
==> default: failed: [192.168.33.99] (item=[u'sys_packages']) => {"failed": true, "item": ["sys_packages"], "msg": "No package matching 'sys_packages' is available"}
```

- run composer in correct directory
```
==> default: Composer could not find a composer.json file in /home/vagrant
==> default: To initialize a project, please create a composer.json file as described in the https://getcomposer.org/ "Getting Started" section
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: stdin: is not a tty
==> default: PHP Warning:  require_once(/vagrant/bin/../app/bootstrap.php.cache): failed to open stream: No such file or directory in /vagrant/bin/load_data.php on line 18
==> default: PHP Fatal error:  require_once(): Failed opening required '/vagrant/bin/../app/bootstrap.php.cache' (include_path='.:/usr/share/php:/usr/share/pear') in /vagrant/bin/load_data.php on line 18
```