### PR TITLE
Update symfony standards

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -1,7 +1,8 @@
 framework:
-    secret: '%env(APP_SECRET)%'
     #csrf_protection: true
+    fragments: true
     #http_method_override: true
+    secret: '%env(APP_SECRET)%'
 
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.
@@ -11,7 +12,6 @@ framework:
         cookie_samesite: lax
 
     #esi: true
-    #fragments: true
     php_errors:
         log: true
 

--- a/src/Sonata/Bundle/DemoBundle/Resources/config/routing/demo.xml
+++ b/src/Sonata/Bundle/DemoBundle/Resources/config/routing/demo.xml
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="sonata_demo_media" path="/media">
-        <default key="_controller">SonataDemoBundle:Demo:media</default>
-    </route>
-    <route id="sonata_demo_car" path="/car">
-        <default key="_controller">SonataDemoBundle:Demo:car</default>
-    </route>
-    <route id="sonata_demo_car_rescue" path="/car-rescue-engine">
-        <default key="_controller">SonataDemoBundle:Demo:carRescueEngine</default>
-    </route>
-    <route id="sonata_demo_newsletter" path="/newsletter" methods="POST">
-        <default key="_controller">SonataDemoBundle:Demo:newsletter</default>
-    </route>
+<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="sonata_demo_media" path="/media" controller="Sonata\Bundle\DemoBundle\Controller\DemoController::mediaAction"/>
+    <route id="sonata_demo_car" path="/car" controller="Sonata\Bundle\DemoBundle\Controller\DemoController::carAction"/>
+    <route id="sonata_demo_car_rescue" path="/car-rescue-engine" controller="Sonata\Bundle\DemoBundle\Controller\DemoController::carRescueEngineAction"/>
+    <route id="sonata_demo_newsletter" path="/newsletter" methods="POST" controller="Sonata\Bundle\DemoBundle\Controller\DemoController::newsletterAction"/>
 </routes>

--- a/src/Sonata/Bundle/DemoBundle/Resources/views/Block/newsletter.html.twig
+++ b/src/Sonata/Bundle/DemoBundle/Resources/views/Block/newsletter.html.twig
@@ -1,3 +1,14 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
 <div class="row">
     <p>Want to stay in touch with us? Subscribe to our monthly newsletter.</p>
 

--- a/src/Sonata/Bundle/DemoBundle/Resources/views/Demo/car.html.twig
+++ b/src/Sonata/Bundle/DemoBundle/Resources/views/Demo/car.html.twig
@@ -1,7 +1,17 @@
-{% extends '::empty.html.twig' %}
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends '@SonataDemo/Demo/empty.html.twig' %}
 
 {% form_theme form _self %}
-
 
 {% block content %}
     <h2>Car Type</h2>
@@ -25,7 +35,6 @@
     <div>
     </div>
 {% endblock %}
-
 
 {% block _sonata_demo_form_type_car_rescueEngine_label %}
     {{ block('form_label') }}

--- a/src/Sonata/Bundle/DemoBundle/Resources/views/Demo/empty.html.twig
+++ b/src/Sonata/Bundle/DemoBundle/Resources/views/Demo/empty.html.twig
@@ -9,4 +9,5 @@ file that was distributed with this source code.
 
 #}
 
-<div class="alert alert-success">{{ message|trans({}, 'SonataDemoBundle') }}</div>
+{% block body %}{% endblock %}
+{% block content %}{% endblock %}

--- a/src/Sonata/Bundle/DemoBundle/Resources/views/Demo/media.html.twig
+++ b/src/Sonata/Bundle/DemoBundle/Resources/views/Demo/media.html.twig
@@ -1,3 +1,14 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
 <h2>Form Media Type & SEO</h2>
 
 <div>

--- a/src/Sonata/Bundle/QABundle/Controller/PageController.php
+++ b/src/Sonata/Bundle/QABundle/Controller/PageController.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\Bundle\QABundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class PageController extends Controller
+class PageController extends AbstractController
 {
     /**
      * This make sure there is no regression to retrieve the current website in a sub request.

--- a/src/Sonata/Bundle/QABundle/Controller/SerializerController.php
+++ b/src/Sonata/Bundle/QABundle/Controller/SerializerController.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace Sonata\Bundle\QABundle\Controller;
 
 use JMS\Serializer\SerializationContext;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class SerializerController extends Controller
+class SerializerController extends AbstractController
 {
     /**
      * This make sure there is no regression to retrieve the current website in a sub request.

--- a/src/Sonata/Bundle/QABundle/Resources/config/routing/qa.xml
+++ b/src/Sonata/Bundle/QABundle/Resources/config/routing/qa.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="sonata_page_bundle_inner_controller" path="/qa/page/controller-helper">
-        <default key="_controller">SonataQABundle:Page:controllerHelper</default>
-    </route>
-    <route id="sonata_qa_serialize" path="/qa/serialize">
-        <default key="_controller">SonataQABundle:Serializer:serialize</default>
-    </route>
+<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="sonata_page_bundle_inner_controller" path="/qa/page/controller-helper" controller="Sonata\Bundle\QABundle\Controller\PageController::controllerHelperAction"/>
+    <route id="sonata_qa_serialize" path="/qa/serialize" controller="Sonata\Bundle\QABundle\Controller\SerializerController::serializeAction"/>
 </routes>

--- a/src/Sonata/Bundle/QABundle/Resources/views/Page/controllerHelper.html.twig
+++ b/src/Sonata/Bundle/QABundle/Resources/views/Page/controllerHelper.html.twig
@@ -1,3 +1,14 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
 <h1>Page Bundle</h1>
 
 <h2>Solving</h2>
@@ -8,8 +19,9 @@
 <h2>Rendering</h2>
 <h3>render_hinclude</h3>
 <pre>
-    {{ render_hinclude(controller('SonataQABundle:Page:internalController'))|e }}
+    {{ render_hinclude(controller('Sonata\\Bundle\\QABundle\\Controller\\PageController::internalControllerAction'))|e }}
 </pre>
 
 <h3>render</h3>
-{{ render(controller('SonataQABundle:Page:internalController')) }}
+
+{{ render(controller('Sonata\\Bundle\\QABundle\\Controller\\PageController::internalControllerAction')) }}

--- a/src/Sonata/Bundle/QABundle/Resources/views/Serializer/serialize.html.twig
+++ b/src/Sonata/Bundle/QABundle/Resources/views/Serializer/serialize.html.twig
@@ -1,3 +1,14 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
 <h1>Serialize test page</h1>
 
 <form action="{{ url('sonata_qa_serialize') }}" method="post">


### PR DESCRIPTION
This PR includes:
- fix for fragments
- add missing sonata header in templates
- change `controllers` properties pattern to current patter