### PR TITLE
fix phing project building on Windows

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,6 @@
     <target name="initialize-project">
         <!-- TODO: check for existence of app/config/parameters.yml -->
         <property name="app.uploadsDir" value="./public/uploads/media"/>
-        <property name="app.console" value="bin/console"/>
         <if>
             <os family="windows"/>
             <then>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
fix phing project building on Windows

The removed line is duplicated in else clause and crashes running command 
`vendor\bin\phing` on windows

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sandbox/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
running `vendor\bin\phing` on windows
```
![Screenshot_3](https://user-images.githubusercontent.com/3856071/101931520-37380d00-3be2-11eb-8470-bab11ee80762.png)

